### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-shamefully-hoist=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
-ignoredBuiltDependencies:
-  - esbuild
-onlyBuiltDependencies:
-  - better-sqlite3
+shamefullyHoist: true
 
+allowBuilds:
+  '@parcel/watcher': false
+  better-sqlite3: true
+  esbuild: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`